### PR TITLE
Handle group memberships with all supported non-expiry parameters

### DIFF
--- a/includes/ExternalWikiPrimaryAuthenticationProvider.php
+++ b/includes/ExternalWikiPrimaryAuthenticationProvider.php
@@ -364,7 +364,7 @@ class ExternalWikiPrimaryAuthenticationProvider	extends AbstractPasswordPrimaryA
 					continue;
 				}
 				
-				if ( in_array( $group>expiry, ['infinite', 'indefinite', 'infinity', 'never'] ) ) {
+				if ( in_array( $group->expiry, ['infinite', 'indefinite', 'infinity', 'never'] ) ) {
 					$group->expiry = null;
 				}
 

--- a/includes/ExternalWikiPrimaryAuthenticationProvider.php
+++ b/includes/ExternalWikiPrimaryAuthenticationProvider.php
@@ -363,6 +363,10 @@ class ExternalWikiPrimaryAuthenticationProvider	extends AbstractPasswordPrimaryA
 				if ( !in_array( $group->group, $validGroups ) ) {
 					continue;
 				}
+				
+				if ( in_array( $group>expiry, ['infinite', 'indefinite', 'infinity', 'never'] ) ) {
+					$group->expiry = null;
+				}
 
 				$this->userGroupManager->addUserToGroup( $user, $group->group, $group->expiry );
 			}


### PR DESCRIPTION
According to MediaWiki API docs:

> Expiry timestamps. May be relative (e.g. 5 months or 2 weeks) or absolute (e.g. 2014-09-18T12:34:56Z). If only one timestamp is set, it will be used for all groups passed to the add parameter. Use infinite, indefinite, infinity, or never for a never-expiring user group.

In my case, the MediaWiki API was returning `'infinity'` for group memberships without expiries.

However, `addUserToGroup` expects either a `wfTimestamp` or a null for non-expiring. This handles the conversion. 